### PR TITLE
Use function-specific roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10087,6 +10087,15 @@
         }
       }
     },
+    "serverless-iam-roles-per-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/serverless-iam-roles-per-function/-/serverless-iam-roles-per-function-2.0.1.tgz",
+      "integrity": "sha512-3t8BsC4CxsXfBtL80xaz5vcRiAe6x4tKfDByGtmMj8fr5q3AvH4PHlhnPPtSYVYgleY02K9Bfh8kf4UrkgshFQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "serverless-pseudo-parameters": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "aws-cdk": "^1.0.0",
     "aws-sdk": "^2.493.0",
     "husky": "^3.0.0",
+    "serverless-iam-roles-per-function": "^2.0.1",
     "serverless-pseudo-parameters": "^2.4.0",
     "skripts": "0.0.16",
     "tslint": "^5.18.0",

--- a/serverless.js
+++ b/serverless.js
@@ -7,7 +7,24 @@ module.exports = {
   custom: {
     ...serverless.custom,
     bucket: "${env:DEPLOYMENT_BUCKET, 'default'}",
+    bucketArn: "arn:aws:s3:::${self:custom.bucket}",
+    eventSourceArn:
+      "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:event-source-mapping:*",
+    keyArn:
+      "arn:aws:s3:::${self:custom.bucket}/serverless/webhook-handler/${self:provider.stage}/*",
+    lambdaArn:
+      "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:${self:custom.project}-*-lambda-${self:provider.stage}",
+    logGroupArn:
+      "arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:*",
+    logStreamArn:
+      "arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:/aws/lambda/${self:custom.project}-*-lambda-${self:provider.stage}:*",
+    policyArn:
+      "arn:aws:iam::#{AWS::AccountId}:policy/${self:custom.project}-*-policy-${self:provider.region}-${self:provider.stage}",
     project,
+    queueArn:
+      "arn:aws:sqs:${self:provider.region}:#{AWS::AccountId}:${self:custom.project}-*-consumer-queue-${self:provider.stage}",
+    roleArn:
+      "arn:aws:iam::#{AWS::AccountId}:role/${self:custom.project}-*-role-${self:provider.region}-${self:provider.stage}",
     tags: {
       ...serverless.custom.tags,
       Project: project,
@@ -16,17 +33,237 @@ module.exports = {
       DeployJobUrl: "${env:BUILD_URL, 'n/a'}",
       "org.label-schema.vcs-url": "${env:GIT_URL, 'n/a'}",
       "org.label-schema.vcs-ref": "${env:GIT_COMMIT, 'n/a'}"
-    }
+    },
+    topicArn:
+      "arn:aws:sns:${self:provider.region}:#{AWS::AccountId}:cloudwatch-alarm-to-slack-topic-${self:provider.stage}"
   },
   functions: {
-    create: { handler: "src/create/handler.handle", timeout: 120 },
-    delete: { handler: "src/delete/handler.handle", timeout: 60 },
-    disable: { handler: "src/disable/handler.handle", timeout: 60 },
-    update: { handler: "src/update/handler.handle", timeout: 120 },
-    updateCode: { handler: "src/updateCode/handler.handle", timeout: 120 }
+    create: {
+      handler: "src/create/handler.handle",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["logs:CreateLogGroup"],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: ["logs:PutMetricFilter", "logs:PutRetentionPolicy"],
+          Resource: "${self:custom.logStreamArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["logs:DescribeLogGroups"],
+          Resource: "${self:custom.logGroupArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["cloudwatch:PutMetricAlarm"],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: ["s3:ListBucket"],
+          Resource: "${self:custom.bucketArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["s3:GetObject"],
+          Resource: "${self:custom.keyArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["sqs:GetQueueUrl", "sqs:GetQueueAttributes"],
+          Resource: [
+            { "Fn::GetAtt": ["ResultQueue98CD34E0", "Arn"] },
+            { "Fn::GetAtt": ["ErrorQueue2580A2D4", "Arn"] }
+          ]
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "sqs:CreateQueue",
+            "sqs:GetQueueAttributes",
+            "sqs:GetQueueUrl",
+            "sqs:TagQueue"
+          ],
+          Resource: "${self:custom.queueArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:ListEventSourceMappings",
+            "lambda:UpdateEventSourceMapping"
+          ],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: ["sns:CreateTopic"],
+          Resource: "${self:custom.topicArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["iam:CreatePolicy"],
+          Resource: "${self:custom.policyArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["lambda:CreateEventSourceMapping"],
+          Resource: "*",
+          Condition: {
+            ArnLike: { "lambda:FunctionArn": "${self:custom.lambdaArn}" }
+          }
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:CreateFunction",
+            "lambda:PutFunctionConcurrency",
+            "lambda:TagResource"
+          ],
+          Resource: "${self:custom.lambdaArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "iam:AttachRolePolicy",
+            "iam:CreateRole",
+            "iam:PassRole",
+            "iam:TagRole"
+          ],
+          Resource: "${self:custom.roleArn}"
+        }
+      ],
+      timeout: 120
+    },
+    delete: {
+      handler: "src/delete/handler.handle",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["logs:DeleteLogGroup", "logs:DeleteMetricFilter"],
+          Resource: "${self:custom.logStreamArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["cloudwatch:DeleteAlarms"],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: ["sqs:DeleteQueue", "sqs:GetQueueUrl"],
+          Resource: "${self:custom.queueArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:ListEventSourceMappings",
+            "lambda:UpdateEventSourceMapping"
+          ],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: ["iam:DeletePolicy"],
+          Resource: "${self:custom.policyArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["lambda:DeleteEventSourceMapping"],
+          Resource: "${self:custom.eventSourceArn}",
+          Condition: {
+            ArnLike: { "lambda:FunctionArn": "${self:custom.lambdaArn}" }
+          }
+        },
+        {
+          Effect: "Allow",
+          Action: ["lambda:DeleteFunction"],
+          Resource: "${self:custom.lambdaArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["iam:DeleteRole", "iam:DetachRolePolicy", "iam:GetRole"],
+          Resource: "${self:custom.roleArn}"
+        }
+      ],
+      timeout: 60
+    },
+    disable: {
+      handler: "src/disable/handler.handle",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["sqs:GetQueueUrl", "sqs:PurgeQueue"],
+          Resource: "${self:custom.queueArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:ListEventSourceMappings",
+            "lambda:UpdateEventSourceMapping"
+          ],
+          Resource: "*"
+        }
+      ],
+      timeout: 60
+    },
+    update: {
+      handler: "src/update/handler.handle",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["sqs:GetQueueUrl", "sqs:SetQueueAttributes"],
+          Resource: "${self:custom.queueArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:GetFunctionConfiguration",
+            "lambda:UpdateFunctionConfiguration",
+            "lambda:PutFunctionConcurrency"
+          ],
+          Resource: "${self:custom.lambdaArn}"
+        }
+      ],
+      timeout: 120
+    },
+    updateCode: {
+      handler: "src/updateCode/handler.handle",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["s3:ListBucket"],
+          Resource: "${self:custom.bucketArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["s3:GetObject"],
+          Resource: "${self:custom.keyArn}"
+        },
+        {
+          Effect: "Allow",
+          Action: ["lambda:ListFunctions"],
+          Resource: "*"
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:UpdateFunctionCode",
+            "lambda:UpdateFunctionConfiguration"
+          ],
+          Resource: "${self:custom.lambdaArn}"
+        }
+      ],
+      timeout: 120
+    }
   },
   package: { individually: "${file(./config.js):packageIndividually}" },
-  plugins: [...serverless.plugins, "serverless-pseudo-parameters"],
+  plugins: [
+    ...serverless.plugins,
+    "serverless-iam-roles-per-function",
+    "serverless-pseudo-parameters"
+  ],
   provider: {
     ...serverless.provider,
     environment: {
@@ -34,140 +271,6 @@ module.exports = {
       DEPLOYMENT_BUCKET: "${self:custom.bucket}",
       ENVIRONMENT: "${self:provider.stage}"
     },
-    iamRoleStatements: [
-      {
-        Effect: "Allow",
-        Action: ["logs:CreateLogGroup"],
-        Resource: "*"
-      },
-      {
-        Effect: "Allow",
-        Action: [
-          "logs:DeleteLogGroup",
-          "logs:PutMetricFilter",
-          "logs:DeleteMetricFilter",
-          "logs:PutRetentionPolicy"
-        ],
-        Resource:
-          "arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:/aws/lambda/${self:custom.project}-*-lambda-${self:provider.stage}:*"
-      },
-      {
-        Effect: "Allow",
-        Action: ["logs:DescribeLogGroups"],
-        Resource:
-          "arn:aws:logs:${self:provider.region}:#{AWS::AccountId}:log-group:*"
-      },
-      {
-        Effect: "Allow",
-        Action: ["cloudwatch:PutMetricAlarm", "cloudwatch:DeleteAlarms"],
-        Resource: "*"
-      },
-      {
-        Effect: "Allow",
-        Action: ["s3:ListBucket"],
-        Resource: "arn:aws:s3:::${self:custom.bucket}"
-      },
-      {
-        Effect: "Allow",
-        Action: ["s3:GetObject"],
-        Resource:
-          "arn:aws:s3:::${self:custom.bucket}/serverless/webhook-handler/${self:provider.stage}/*"
-      },
-      {
-        Effect: "Allow",
-        Action: ["sqs:GetQueueUrl", "sqs:GetQueueAttributes"],
-        Resource: [
-          { "Fn::GetAtt": ["ResultQueue98CD34E0", "Arn"] },
-          { "Fn::GetAtt": ["ErrorQueue2580A2D4", "Arn"] }
-        ]
-      },
-      {
-        Effect: "Allow",
-        Action: [
-          "sqs:CreateQueue",
-          "sqs:DeleteQueue",
-          "sqs:GetQueueAttributes",
-          "sqs:GetQueueUrl",
-          "sqs:PurgeQueue",
-          "sqs:SetQueueAttributes",
-          "sqs:TagQueue"
-        ],
-        Resource:
-          "arn:aws:sqs:${self:provider.region}:#{AWS::AccountId}:${self:custom.project}-*-consumer-queue-${self:provider.stage}"
-      },
-      {
-        Effect: "Allow",
-        Action: [
-          "lambda:ListEventSourceMappings",
-          "lambda:ListFunctions",
-          "lambda:UpdateEventSourceMapping"
-        ],
-        Resource: "*"
-      },
-      {
-        Effect: "Allow",
-        Action: ["lambda:CreateEventSourceMapping"],
-        Resource: "*",
-        Condition: {
-          ArnLike: {
-            "lambda:FunctionArn":
-              "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:${self:custom.project}-*-lambda-${self:provider.stage}"
-          }
-        }
-      },
-      {
-        Effect: "Allow",
-        Action: ["lambda:DeleteEventSourceMapping"],
-        Resource:
-          "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:event-source-mapping:*",
-        Condition: {
-          ArnLike: {
-            "lambda:FunctionArn":
-              "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:${self:custom.project}-*-lambda-${self:provider.stage}"
-          }
-        }
-      },
-      {
-        Effect: "Allow",
-        Action: [
-          "lambda:CreateFunction",
-          "lambda:DeleteFunction",
-          "lambda:GetFunctionConfiguration",
-          "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration",
-          "lambda:PutFunctionConcurrency",
-          "lambda:TagResource"
-        ],
-        Resource:
-          "arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:${self:custom.project}-*-lambda-${self:provider.stage}"
-      },
-      {
-        Effect: "Allow",
-        Action: [
-          "iam:AttachRolePolicy",
-          "iam:CreateRole",
-          "iam:DeleteRole",
-          "iam:DetachRolePolicy",
-          "iam:GetRole",
-          "iam:PassRole",
-          "iam:TagRole"
-        ],
-        Resource:
-          "arn:aws:iam::#{AWS::AccountId}:role/${self:custom.project}-*-role-${self:provider.region}-${self:provider.stage}"
-      },
-      {
-        Effect: "Allow",
-        Action: ["iam:CreatePolicy", "iam:DeletePolicy"],
-        Resource:
-          "arn:aws:iam::#{AWS::AccountId}:policy/${self:custom.project}-*-policy-${self:provider.region}-${self:provider.stage}"
-      },
-      {
-        Effect: "Allow",
-        Action: ["sns:CreateTopic"],
-        Resource:
-          "arn:aws:sns:${self:provider.region}:#{AWS::AccountId}:cloudwatch-alarm-to-slack-topic-${self:provider.stage}"
-      }
-    ],
     timeout: 30
   },
   resources: "${file(./scripts/stack.yml)}"

--- a/test/create/createRole.test.ts
+++ b/test/create/createRole.test.ts
@@ -16,7 +16,7 @@ iam.mockImplementationOnce(() => ({
 }))
 import { createRole as cr } from "../../src/create/createRole"
 
-test("createLogGroup", async () => {
+test("createRole", async () => {
   const cId = 123
   const c = { x: 0 }
   const cp = { x: 1 }


### PR DESCRIPTION
Following the principle of least privilege, this moves to function-specific roles instead of one role all functions share. Tested each function in AWS Sandbox.