### PR TITLE
PRD-177: Use SKRIPTS_DEPLOYMENT_BUCKET env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "npm run build:stack && sls deploy",
     "deploy:docker": "npm run build:docker && cd .webpack/service && skripts docker-publish docker.dwolla.net/dwolla/webhook-provisioner --tag $(git rev-parse HEAD)",
     "format": "skripts format",
-    "jest": "ENVIRONMENT=test DEPLOYMENT_BUCKET=bucket jest",
+    "jest": "ENVIRONMENT=test SKRIPTS_DEPLOYMENT_BUCKET=bucket jest",
     "lint": "skripts lint --fix",
     "start": "npm run build && cd .webpack/service && node server.js",
     "test": "npm run lint && npm run build:stack && npm run jest && sls package",

--- a/scripts/stack.ts
+++ b/scripts/stack.ts
@@ -177,7 +177,9 @@ const create = async () => {
   stack.node.applyAspect(new Tag("Creator", "serverless"))
   stack.node.applyAspect(new Tag("Team", "growth"))
   stack.node.applyAspect(new Tag("Visibility", "external"))
-  if (BUILD_URL) stack.node.applyAspect(new Tag("DeployJobUrl", BUILD_URL))
+  if (BUILD_URL) {
+    stack.node.applyAspect(new Tag("DeployJobUrl", BUILD_URL))
+  }
   if (GIT_URL) {
     stack.node.applyAspect(new Tag("org.label-schema.vcs-url", GIT_URL))
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@ import { IConcurrency, Res } from "."
 import { toRes } from "./mapper"
 
 export const BATCH = 10
-export const DEPLOYMENT_BUCKET = envVar("DEPLOYMENT_BUCKET")
+export const DEPLOYMENT_BUCKET = envVar("SKRIPTS_DEPLOYMENT_BUCKET")
 export const ENV = envVar("ENVIRONMENT")
 export const PROJECT = "webhooks"
 export const REGION = process.env.AWS_REGION || "us-west-2"

--- a/test/create/mapper.test.ts
+++ b/test/create/mapper.test.ts
@@ -144,7 +144,7 @@ test("toQueueDepthAlarm", () => {
     Period: 900,
     Statistic: "Average",
     Threshold: 900,
-    TreatMissingData: "ignore"
+    TreatMissingData: "ignore",
   })
 })
 
@@ -165,7 +165,7 @@ test("toLambdaErrorAlarm", () => {
     Period: 60,
     Statistic: "Sum",
     Threshold: 1,
-    TreatMissingData: "ignore"
+    TreatMissingData: "ignore",
   })
 })
 
@@ -186,7 +186,7 @@ test("toLogErrorAlarm", () => {
     Period: 60,
     Statistic: "Sum",
     Threshold: 1,
-    TreatMissingData: "ignore"
+    TreatMissingData: "ignore",
   })
 })
 


### PR DESCRIPTION
Update `util.ts` to use the `SKRIPTS_DEPLOYMENT_BUCKET` environment variable.

No other code substantially changed (excepting linting errors) so just need to verify that unit tests run by running `nvm install && npm ci && ENVIRONMENT=local npm test`.