### PR TITLE
treat missing data as not breaching for logmetrics alarms

### DIFF
--- a/scripts/stack.ts
+++ b/scripts/stack.ts
@@ -2,6 +2,7 @@ import {
   ComparisonOperator,
   DimensionHash,
   Metric,
+  TreatMissingData,
 } from "@aws-cdk/aws-cloudwatch"
 import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions"
 import { CfnMetricFilter, LogGroup } from "@aws-cdk/aws-logs"
@@ -29,6 +30,7 @@ type AlarmProps = Readonly<{
   period?: Duration
   statistic?: string
   threshold?: number
+  treatMissingData?: TreatMissingData
 }>
 
 type QueueProps = Readonly<{
@@ -152,6 +154,7 @@ class MyStack extends Stack {
       alarmName: metricName,
       metricName,
       namespace,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
     })
   }
 
@@ -170,6 +173,7 @@ class MyStack extends Stack {
         period: props.period || Duration.minutes(1),
         statistic: props.statistic || "Sum",
         threshold: props.threshold || 1,
+        treatMissingData: props.treatMissingData || TreatMissingData.MISSING,
       })
       .addAlarmAction(new SnsAction(this.topic))
 }


### PR DESCRIPTION
## Problem
An alarm has been stuck in "In Alarm" state since the alarm fired 2-3 weeks ago. For context, the alarm is in the `LogMetrics` namespace, monitors a webhook lambda for errors, and has a period of 60 seconds / threshold of 1.

## Solution 
 From [AWS Docs - Configuring How Alarms Treat Missing Data](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html) cloudwatch ignores missing data by default and the alarm state is maintained. Currently we do not configure how alarms should handle missing data, so I think this behavior is expected.

Configure cloudwatch to treat missing data as `NON_BREACHING` instead of the `IGNORE` default for alarms in the `LogMetrics` namespace.
