### PR TITLE
DD-796 move env var function to separate file

### DIFF
--- a/scripts/stack.ts
+++ b/scripts/stack.ts
@@ -13,8 +13,8 @@ import {
   Aspects,
 } from "@aws-cdk/core"
 import { name } from "../package.json"
-import { ENV } from "../src/util"
 import { DimensionsMap } from "@aws-cdk/aws-cloudwatch/lib/metric"
+import { envVarRequired } from "../src/envVarUtil"
 
 type AlarmProps = Readonly<{
   alarmName: string
@@ -40,6 +40,7 @@ const GIT_COMMIT = process.env.GIT_COMMIT
 const GIT_URL = process.env.GIT_URL
 const PROJECT = "webhooks"
 const REGION = process.env.AWS_REGION || "us-west-2"
+const ENV = envVarRequired("ENVIRONMENT")
 
 const resourceName = (
   resource: string,

--- a/src/envVarUtil.ts
+++ b/src/envVarUtil.ts
@@ -1,0 +1,7 @@
+export const envVarRequired = (name: string): string => {
+  const envVar = process.env[name]
+  if (envVar) {
+    return envVar
+  }
+  throw new Error(`${name} required`)
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,14 +3,7 @@ import { AWSError } from "aws-sdk"
 import { IConcurrency, Res } from "."
 import { toRes } from "./mapper"
 import { error, log, warn } from "./logger"
-
-export const envVarRequired = (name: string): string => {
-  const envVar = process.env[name]
-  if (envVar) {
-    return envVar
-  }
-  throw new Error(`${name} required`)
-}
+import { envVarRequired } from "./envVarUtil"
 
 export const BATCH = 10
 export const DEPLOYMENT_BUCKET = envVarRequired("DEPLOYMENT_BUCKET")


### PR DESCRIPTION
The utils file is used to get ENV variables at lambda runtime. We were importing `ENV` from this file to use in the stack creating process. This was casing a circular dependency  where the variables need to set while the stack is created but they would be set at lambda run time.