### PR TITLE
DD-1731 add new lambda to update code to select consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/async-retry": "^1.4.5",
+        "@types/aws-lambda": "^8.10.143",
         "@types/jest": "^29.5.2",
         "@types/jest-when": "3.5.2",
         "@types/node": "^20.2.5",
@@ -3092,6 +3093,12 @@
       "dependencies": {
         "@types/retry": "*"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.143",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.143.tgz",
+      "integrity": "sha512-u5vzlcR14ge/4pMTTMDQr3MF0wEe38B2F9o84uC4F43vN5DGTy63npRrB6jQhyt+C0lGv4ZfiRcRkqJoZuPnmg==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.5",
+    "@types/aws-lambda": "^8.10.143",
     "@types/jest": "^29.5.2",
     "@types/jest-when": "3.5.2",
     "@types/node": "^20.2.5",

--- a/serverless.js
+++ b/serverless.js
@@ -266,6 +266,36 @@ module.exports = {
       ],
       timeout: 120,
     },
+    updateConsumersCode: {
+      handler: "src/updateCode/handler.updateConsumersCodeHandler",
+      iamRoleStatements: [
+        {
+          Effect: "Allow",
+          Action: ["s3:ListBucket"],
+          Resource: "${self:custom.bucketArn}",
+        },
+        {
+          Effect: "Allow",
+          Action: ["s3:GetObject"],
+          Resource: "${self:custom.keyArn}",
+        },
+        {
+          Effect: "Allow",
+          Action: ["lambda:ListFunctions"],
+          Resource: "*",
+        },
+        {
+          Effect: "Allow",
+          Action: [
+            "lambda:UpdateFunctionCode",
+            "lambda:UpdateFunctionConfiguration",
+            "lambda:GetFunction",
+          ],
+          Resource: "${self:custom.lambdaArn}",
+        },
+      ],
+      timeout: 120,
+    },
   },
   package: {
     individually: '${file(./config.js):packageIndividually(), "false"}',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import { Handler } from "aws-lambda/handler"
+
 export type ConsumerId = number | string
 
 export interface IEvent {
@@ -56,6 +58,25 @@ export type CreateFuncReq = Readonly<{
 export interface IFunc {
   arn: string
   eventSourceId?: string
+  name?: string
 }
 
 export type LogGroup = Readonly<{ arn: string }>
+
+export type UpdateConsumersCodeRequest = {
+  consumerIds: ConsumerId[]
+  nodeVersion: string
+  codeName: string
+}
+
+export type UpdateConsumersCodeResponse = {
+  statusCode: number
+  body: {
+    message: string
+  }
+}
+
+export type UpdateConsumersCodeHandler = Handler<
+  UpdateConsumersCodeRequest,
+  UpdateConsumersCodeResponse
+>

--- a/src/lambdaHelpers.ts
+++ b/src/lambdaHelpers.ts
@@ -1,0 +1,11 @@
+import Lambda, { EnvironmentVariables } from "aws-sdk/clients/lambda"
+const lam = new Lambda()
+
+export const getLambdaEnvVars = async (
+  ln: string
+): Promise<EnvironmentVariables> => {
+  const env = (
+    await lam.getFunctionConfiguration({ FunctionName: ln }).promise()
+  ).Environment
+  return env?.Variables ?? {}
+}

--- a/src/latestCode.ts
+++ b/src/latestCode.ts
@@ -1,6 +1,8 @@
-import S3 from "aws-sdk/clients/s3"
+import S3, { ListObjectsV2Request } from "aws-sdk/clients/s3"
 import { Location } from "."
 import { DEPLOYMENT_BUCKET, ENV, logRes } from "./util"
+import { log } from "./logger"
+import { s3ToLocation } from "./mapper"
 
 const s3 = new S3()
 
@@ -10,20 +12,61 @@ export const latestCode = async (): Promise<Location> =>
       Bucket: DEPLOYMENT_BUCKET,
       Prefix: `serverless/webhook-handler/${ENV}/`,
     }
-    const err = new Error(`Code not in ${ps.Bucket}/${ps.Prefix}`)
-    const contents = (await s3.listObjectsV2(ps).promise()).Contents
-    if (!contents || !contents.length) throw err
+    const contents = await listObjects(ps)
 
-    const filtered = contents
-      .filter((c) => c.Key && c.Key.includes("func.zip"))
+    const sortedList = filterS3Objects(contents)
       .map((c) => c.Key as string)
       .sort((a, b) => (a > b ? -1 : 1))
-    if (!filtered.length) throw err
 
-    const key = filtered[0]
-    return {
-      bucket: ps.Bucket,
-      key,
-      version: key.split("/")[3].split("-").slice(1).join("-"),
-    }
+    const key = sortedList[0]
+
+    return s3ToLocation(ps.Bucket, key)
   })
+
+export const codeExists = async (codeVersion: string): Promise<Location> => {
+  const listRequest = {
+    Bucket: DEPLOYMENT_BUCKET,
+    Prefix: `serverless/webhook-handler/${ENV}/*-${codeVersion}/`,
+  }
+
+  const contents = await listObjects(listRequest)
+
+  const filteredObjects = filterS3Objects(contents)
+
+  if (filteredObjects.length !== 1) {
+    throw new Error(
+      `Unexpected number of code packages returned for code version: ${codeVersion}`
+    )
+  }
+
+  const key = filteredObjects[0].Key
+  if (!key) {
+    throw new Error(`Key value was not returned from list s3 object`)
+  }
+
+  return s3ToLocation(listRequest.Bucket, key)
+}
+
+const listObjects = async (
+  request: ListObjectsV2Request
+): Promise<S3.ObjectList> => {
+  log(`Listing s3 objects for ${request.Bucket}/${request.Prefix}`)
+  const result = await s3.listObjectsV2(request).promise()
+  const contents = result.Contents
+
+  if (!contents?.length) {
+    throw new Error(`Code not in ${request.Bucket}/${request.Prefix}`)
+  }
+
+  return contents
+}
+
+const filterS3Objects = (contents: S3.ObjectList): S3.Object[] => {
+  const filteredList = contents.filter((c) => c?.Key?.includes("func.zip"))
+
+  if (!filteredList.length) {
+    throw new Error(`Filtered s3 list returned 0 matches`)
+  }
+
+  return filteredList
+}

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -1,4 +1,4 @@
-import { ConsumerId, Res } from "."
+import { ConsumerId, Location, Res } from "."
 import { ENV, PROJECT, REGION } from "./util"
 
 export const toRes = (body: object, statusCode = 200): Res => ({
@@ -46,3 +46,12 @@ const resourceName = (
   `${PROJECT}${
     typeof resourceId === "undefined" ? "" : `-${resourceId}`
   }-${resource}${includeRegion ? `-${REGION}` : ""}-${ENV}`
+
+export const s3ToLocation = (bucket: string, key: string): Location => {
+  const version = key.split("/")[3].split("-").slice(1).join("-")
+  return {
+    bucket,
+    key,
+    version,
+  }
+}

--- a/src/updateCode/handler.ts
+++ b/src/updateCode/handler.ts
@@ -1,10 +1,37 @@
 import "source-map-support/register"
-import { Res } from ".."
+import {
+  Res,
+  UpdateConsumersCodeHandler,
+  UpdateConsumersCodeRequest,
+  UpdateConsumersCodeResponse,
+} from ".."
+import { error, log } from "../logger"
 import { withErrHandling } from "../util"
-import { updateAll } from "./update"
+import { updateAll, updateByConsumerIds } from "./update"
+import { validateUpdateConsumersCodeRequest } from "./util"
 
 export const handle = async (): Promise<Res> =>
   await withErrHandling(async () => {
     await updateAll()
     return { success: true }
   })
+
+export const updateConsumersCodeHandler: UpdateConsumersCodeHandler = async (
+  request: UpdateConsumersCodeRequest
+): Promise<UpdateConsumersCodeResponse> => {
+  try {
+    log("Request received", request)
+    const validRequest = validateUpdateConsumersCodeRequest(request)
+    return updateByConsumerIds(validRequest)
+  } catch (e: any) {
+    error(
+      `Error returned during processing handling, errorMessage=${e.message}`
+    )
+    return {
+      statusCode: 500,
+      body: {
+        message: e.message,
+      },
+    }
+  }
+}

--- a/src/updateCode/util.ts
+++ b/src/updateCode/util.ts
@@ -1,0 +1,30 @@
+import { UpdateConsumersCodeRequest } from "../index"
+
+const validateUpdateConsumersCodeRequest = (
+  request: UpdateConsumersCodeRequest
+): UpdateConsumersCodeRequest => {
+  if (!Array.isArray(request.consumerIds) || request.consumerIds.length === 0) {
+    throw new Error("Consumers array is empty or not provided")
+  }
+
+  if (!request.codeName || request.codeName.trim() === "") {
+    throw new Error("Code name is empty or not provided")
+  }
+
+  if (!request.nodeVersion || request.nodeVersion.trim() === "") {
+    throw new Error("Node version is empty or not provided")
+  }
+
+  const validNodeVersions = ["nodejs16.x", "nodejs20.x"]
+  if (!validNodeVersions.includes(request.nodeVersion.trim())) {
+    throw new Error("Node version is not supported")
+  }
+
+  return {
+    consumerIds: request.consumerIds,
+    codeName: request.codeName.trim(),
+    nodeVersion: request.nodeVersion.trim(),
+  }
+}
+
+export { validateUpdateConsumersCodeRequest }

--- a/test/lambdaHelpers.test.ts
+++ b/test/lambdaHelpers.test.ts
@@ -1,0 +1,85 @@
+import Lambda from "aws-sdk/clients/lambda"
+import { when } from "jest-when"
+
+jest.mock("aws-sdk/clients/lambda")
+const lambdaMock = Lambda as unknown as jest.Mock
+const getFunctionConfigurationMock = jest.fn()
+lambdaMock.mockImplementationOnce(() => ({
+  getFunctionConfiguration: getFunctionConfigurationMock,
+}))
+import { getLambdaEnvVars } from "../src/lambdaHelpers"
+
+describe("lambdaHelpers", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("getLambdaEnvVars", () => {
+    it("should return existing env vars", async () => {
+      const request = "functionName"
+      const envVariables: Lambda.EnvironmentResponse = {
+        Variables: {
+          TEST_VAR: "test-value",
+        },
+      }
+
+      when(getFunctionConfigurationMock)
+        .calledWith({ FunctionName: request })
+        .mockReturnValue({
+          promise: () => Promise.resolve({ Environment: envVariables }),
+        })
+
+      const envVars = await getLambdaEnvVars(request)
+
+      expect(envVars).toEqual(envVariables.Variables)
+      expect(getFunctionConfigurationMock).toBeCalledTimes(1)
+    })
+
+    it("should return empty env vars returned from lambda", async () => {
+      const request = "functionName"
+      const envVariables: Lambda.EnvironmentResponse = {
+        Variables: {},
+      }
+
+      when(getFunctionConfigurationMock)
+        .calledWith({ FunctionName: request })
+        .mockReturnValue({
+          promise: () => Promise.resolve({ Environment: envVariables }),
+        })
+
+      const envVars = await getLambdaEnvVars(request)
+
+      expect(envVars).toEqual(envVariables.Variables)
+      expect(getFunctionConfigurationMock).toBeCalledTimes(1)
+    })
+
+    it("should return default env vars if none returned from lambda request", async () => {
+      const request = "functionName"
+      const envVariables: Lambda.EnvironmentResponse = {}
+
+      when(getFunctionConfigurationMock)
+        .calledWith({ FunctionName: request })
+        .mockReturnValue({
+          promise: () => Promise.resolve({ Environment: envVariables }),
+        })
+
+      const envVars = await getLambdaEnvVars(request)
+
+      expect(envVars).toEqual({})
+      expect(getFunctionConfigurationMock).toBeCalledTimes(1)
+    })
+
+    it("should return default env vars if environment is not returned", async () => {
+      const request = "functionName"
+
+      when(getFunctionConfigurationMock)
+        .calledWith({ FunctionName: request })
+        .mockReturnValue({ promise: () => Promise.resolve({}) })
+
+      const envVars = await getLambdaEnvVars(request)
+
+      expect(envVars).toEqual({})
+      expect(getFunctionConfigurationMock).toBeCalledTimes(1)
+    })
+  })
+})

--- a/test/latestCode.test.ts
+++ b/test/latestCode.test.ts
@@ -1,15 +1,20 @@
 import S3 from "aws-sdk/clients/s3"
+import { s3ToLocation } from "../src/mapper"
 
 jest.mock("aws-sdk/clients/s3")
+jest.mock("../src/mapper")
 const s3 = S3 as unknown as jest.Mock
 const listObjectsV2 = jest.fn()
 s3.mockImplementationOnce(() => ({ listObjectsV2 }))
-import { latestCode } from "../src/latestCode"
+
+const s3toLocationMock = jest.mocked(s3ToLocation)
+
+import { codeExists, latestCode } from "../src/latestCode"
+import { when } from "jest-when"
 
 describe("latestCode", () => {
   const prefix = "serverless/webhook-handler/test/"
   const err = new Error(`Code not in bucket/${prefix}`)
-
   it("throws error if no contents", async () => {
     listObjectsV2.mockReturnValue({ promise: () => ({}) })
     await expect(latestCode()).rejects.toEqual(err)
@@ -24,7 +29,9 @@ describe("latestCode", () => {
     listObjectsV2.mockReturnValue({
       promise: () => ({ Contents: [{ Key: "" }] }),
     })
-    await expect(latestCode()).rejects.toEqual(err)
+    await expect(latestCode()).rejects.toEqual(
+      new Error(`Filtered s3 list returned 0 matches`)
+    )
   })
 
   it("returns latestCode", async () => {
@@ -33,10 +40,68 @@ describe("latestCode", () => {
       promise: () => ({ Contents: [{ Key: key }] }),
     })
 
-    expect(await latestCode()).toEqual({
+    const expected = {
       bucket: "bucket",
       key,
       version: "2019-02-01T16:41:33.184Z",
+    }
+
+    when(s3toLocationMock).calledWith("bucket", key).mockReturnValue(expected)
+
+    expect(await latestCode()).toEqual(expected)
+  })
+})
+
+describe("codeExists", () => {
+  const bucket = "bucket"
+  const codeVersion = "2024-08-27T16:41:33.184Z"
+  const prefix = `serverless/webhook-handler/test/1549039293184-${codeVersion}/`
+  const prefixMatch = `serverless/webhook-handler/test/*-${codeVersion}/`
+
+  test("returns true if code location if it exists", async () => {
+    const key = `${prefix}func.zip`
+
+    const expected = {
+      bucket: bucket,
+      key,
+      version: codeVersion,
+    }
+
+    listObjectsV2.mockReturnValue({
+      promise: () => ({ Contents: [{ Key: key }] }),
     })
+
+    when(s3toLocationMock).calledWith(bucket, key).mockReturnValue(expected)
+
+    expect(await codeExists(codeVersion)).toEqual(expected)
+  })
+
+  test("throw an error if list objects returns no objects", async () => {
+    const expected = new Error(`Code not in ${bucket}/${prefixMatch}`)
+
+    listObjectsV2.mockReturnValue({ promise: () => ({ Contents: [] }) })
+    await expect(codeExists(codeVersion)).rejects.toEqual(expected)
+  })
+
+  test("throw an error if filtered objects returns no objects", async () => {
+    const expected = new Error(`Filtered s3 list returned 0 matches`)
+
+    listObjectsV2.mockReturnValue({
+      promise: () => ({ Contents: [{ Key: "BadMatch" }] }),
+    })
+    await expect(codeExists(codeVersion)).rejects.toEqual(expected)
+  })
+
+  test("throw an error if multiple filtered objects are returned", async () => {
+    const expected = new Error(
+      `Unexpected number of code packages returned for code version: ${codeVersion}`
+    )
+
+    listObjectsV2.mockReturnValue({
+      promise: () => ({
+        Contents: [{ Key: "test1/func.zip" }, { Key: "test2/func.zip" }],
+      }),
+    })
+    await expect(codeExists(codeVersion)).rejects.toStrictEqual(expected)
   })
 })

--- a/test/mapper.test.ts
+++ b/test/mapper.test.ts
@@ -10,6 +10,7 @@ import {
   queueName,
   resultQueueName,
   roleName,
+  s3ToLocation,
   topicName,
 } from "../src/mapper"
 
@@ -53,3 +54,17 @@ test("roleName", () =>
 
 test("topicName", () =>
   expect(topicName()).toBe(`cloudwatch-alarm-to-slack-topic-test`))
+
+describe("s3ToLocation", () => {
+  test("should s3 bucket and key to a Location", () => {
+    const bucket = "bucket"
+    const version = "2024-09-01T16:41:33.184Z"
+    const key = `serverless/webhook-handler/test/1549039293184-${version}/func.zip`
+
+    expect(s3ToLocation(bucket, key)).toStrictEqual({
+      bucket,
+      key,
+      version,
+    })
+  })
+})

--- a/test/updateCode/handler.test.ts
+++ b/test/updateCode/handler.test.ts
@@ -1,11 +1,26 @@
-import * as u from "../../src/updateCode/update"
+import { updateAll, updateByConsumerIds } from "../../src/updateCode/update"
+import { validateUpdateConsumersCodeRequest } from "../../src/updateCode/util"
+import {
+  handle,
+  updateConsumersCodeHandler,
+} from "../../src/updateCode/handler"
+import { when } from "jest-when"
+import {
+  UpdateConsumersCodeRequest,
+  UpdateConsumersCodeResponse,
+} from "../../src"
+import { Context } from "aws-lambda"
 
 jest.mock("../../src/updateCode/update")
-const updateAll = u.updateAll as jest.Mock
-import { handle } from "../../src/updateCode/handler"
+jest.mock("../../src/updateCode/util")
+const updateAllMock = jest.mocked(updateAll)
+const updateByConsumerIdsMock = jest.mocked(updateByConsumerIds)
+const validateUpdateConsumersCodeRequestMock = jest.mocked(
+  validateUpdateConsumersCodeRequest
+)
 
 describe("handler", () => {
-  afterEach(() => updateAll.mockClear())
+  afterEach(() => updateAllMock.mockClear())
 
   it("returns result", async () => {
     await expect(handle()).resolves.toEqual({
@@ -18,7 +33,7 @@ describe("handler", () => {
 
   it("returns error on exception", async () => {
     const err = "my-error"
-    updateAll.mockRejectedValue(new Error(err))
+    updateAllMock.mockRejectedValue(new Error(err))
 
     await expect(handle()).resolves.toEqual({
       body: JSON.stringify({ error: err }),
@@ -26,5 +41,113 @@ describe("handler", () => {
     })
 
     expect(updateAll).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("updateByConsumersCodeHandler", () => {
+  const context: Context = {
+    callbackWaitsForEmptyEventLoop: false,
+    functionName: "test",
+    functionVersion: "test",
+    invokedFunctionArn: "test",
+    memoryLimitInMB: "test",
+    awsRequestId: "test",
+    logGroupName: "test",
+    logStreamName: "test",
+    getRemainingTimeInMillis: jest.fn(),
+    done: jest.fn(),
+    fail: jest.fn(),
+    succeed: jest.fn(),
+  }
+
+  const request: UpdateConsumersCodeRequest = {
+    consumerIds: ["app1", 123],
+    nodeVersion: "node-version",
+    codeName: "code-name",
+  }
+
+  const successResponse: UpdateConsumersCodeResponse = {
+    statusCode: 200,
+    body: {
+      message: "success",
+    },
+  }
+
+  beforeEach(() => {
+    when(validateUpdateConsumersCodeRequestMock)
+      .calledWith(request)
+      .mockReturnValue(request)
+
+    when(updateByConsumerIdsMock)
+      .calledWith(request)
+      .mockResolvedValue(successResponse)
+  })
+
+  afterEach(() => {
+    updateByConsumerIdsMock.mockClear()
+    validateUpdateConsumersCodeRequestMock.mockClear()
+  })
+
+  test("should return error if validation error is present", async () => {
+    const errorMessage = "validation error message"
+
+    when(validateUpdateConsumersCodeRequestMock)
+      .calledWith(request)
+      .mockImplementationOnce(() => {
+        throw new Error(errorMessage)
+      })
+
+    const expected: UpdateConsumersCodeResponse = {
+      statusCode: 500,
+      body: {
+        message: errorMessage,
+      },
+    }
+
+    const results = await updateConsumersCodeHandler(
+      request,
+      context,
+      jest.fn()
+    )
+
+    expect(results).toEqual(expected)
+    expect(updateByConsumerIds).toHaveBeenCalledTimes(0)
+  })
+
+  test("should return error if update function returned an error", async () => {
+    const errorMessage = "update by consumer ids error"
+
+    when(updateByConsumerIdsMock)
+      .calledWith(request)
+      .mockImplementationOnce(() => {
+        throw new Error(errorMessage)
+      })
+
+    const expected: UpdateConsumersCodeResponse = {
+      statusCode: 500,
+      body: {
+        message: errorMessage,
+      },
+    }
+
+    const results = await updateConsumersCodeHandler(
+      request,
+      context,
+      jest.fn()
+    )
+
+    expect(results).toEqual(expected)
+    expect(updateByConsumerIds).toHaveBeenCalledTimes(1)
+  })
+
+  test("should return success if update function executed successfully", async () => {
+    const results = await updateConsumersCodeHandler(
+      request,
+      context,
+      jest.fn()
+    )
+
+    expect(results).toEqual(successResponse)
+    expect(updateByConsumerIds).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/updateCode/update.test.ts
+++ b/test/updateCode/update.test.ts
@@ -1,34 +1,45 @@
 import Lambda from "aws-sdk/clients/lambda"
-import * as lc from "../../src/latestCode"
+import { codeExists, latestCode } from "../../src/latestCode"
+import { getLambdaEnvVars } from "../../src/lambdaHelpers"
+import { Location } from "../../src"
 
 jest.mock("aws-sdk/clients/lambda")
 jest.mock("../../src/latestCode")
+jest.mock("../../src/lambdaHelpers")
+
 const updateFunctionCode = jest.fn()
 const updateFunctionConfiguration = jest.fn()
 const listFunctions = jest.fn()
 const waitFor = jest.fn()
 const lam = Lambda as unknown as jest.Mock
-lam.mockImplementationOnce(() => ({
+lam.mockImplementation(() => ({
   listFunctions,
   updateFunctionCode,
   updateFunctionConfiguration,
   waitFor,
 }))
-const latestCode = lc.latestCode as jest.Mock
-import { updateAll } from "../../src/updateCode/update"
+const latestCodeMock = jest.mocked(latestCode)
+const codeExistsMock = jest.mocked(codeExists)
+const getLambdaEnvVarsMock = jest.mocked(getLambdaEnvVars)
+
+import { updateAll, updateByConsumerIds } from "../../src/updateCode/update"
+import { ConsumerId, UpdateConsumersCodeRequest } from "../../src"
+import { when } from "jest-when"
+
+const validLambdaName = (n: ConsumerId) => `webhooks-${n}-lambda-test`
+const validLambdaNameWithApplicationId = (n: ConsumerId) =>
+  `webhooks-app${n}-lambda-test`
+const concurrency = "5"
 
 test("update", async () => {
   const resourceName = "a"
-  const concurrency = "5"
   const ver = 1
   const configurationRequest = {
     bucket: "b",
     key: "k",
     version: (ver + 1).toString(),
   }
-  const validLambdaName = (n: number) => `webhooks-${n}-lambda-test`
-  const validLambdaNameWithApplicationId = (n: number) =>
-    `webhooks-app${n}-lambda-test`
+
   let i = 0
   const noName = { Environment: { Variables: { VERSION: ver.toString() } } }
   const wrongName = {
@@ -78,7 +89,7 @@ test("update", async () => {
     }),
   })
   listFunctions.mockReturnValueOnce({ promise: () => ({ Functions: [] }) })
-  latestCode.mockResolvedValue(configurationRequest)
+  latestCodeMock.mockResolvedValue(configurationRequest)
   updateFunctionCode.mockReturnValue({ promise: () => ({}) })
   waitFor.mockReturnValue({ promise: () => ({}) })
   updateFunctionConfiguration.mockReturnValue({
@@ -86,11 +97,11 @@ test("update", async () => {
   })
 
   await expect(updateAll()).resolves.toEqual([
-    { arn: resourceName },
-    { arn: resourceName },
+    { arn: resourceName, name: functionName },
+    { arn: resourceName, name: stringFunctionName },
   ])
 
-  expect(latestCode).toHaveBeenCalledTimes(1)
+  expect(latestCodeMock).toHaveBeenCalledTimes(1)
   expect(listFunctions).toHaveBeenCalledTimes(2)
   expect(listFunctions).toHaveBeenCalledWith({})
   expect(listFunctions).toHaveBeenCalledWith({ Marker: 1 })
@@ -136,5 +147,137 @@ test("update", async () => {
     MemorySize: 128,
     Runtime: "nodejs20.x",
     Timeout: 32,
+  })
+})
+
+describe("updateByConsumerIds", () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const codeName = "2024-08-27T16:41:33.184Z"
+  const request: UpdateConsumersCodeRequest = {
+    codeName: codeName,
+    nodeVersion: "nodejs20.x",
+    consumerIds: [1, "app2"],
+  }
+
+  const initCodeLocationMock = (codeName: string) => {
+    const codeLocation = {
+      bucket: "bucket",
+      key: `startingLocation/123456789-${codeName}/func.zip`,
+      version: codeName,
+    }
+
+    when(codeExistsMock).calledWith(codeName).mockResolvedValue(codeLocation)
+
+    return codeLocation
+  }
+
+  when(getLambdaEnvVarsMock)
+    .calledWith(validLambdaName(request.consumerIds[0]))
+    .mockResolvedValue({
+      VERSION: codeName,
+      ENVIRONMENT: "local",
+      CONCURRENCY: concurrency,
+    })
+
+  when(getLambdaEnvVarsMock)
+    .calledWith(validLambdaName(request.consumerIds[1]))
+    .mockResolvedValue({
+      VERSION: codeName,
+      ENVIRONMENT: "local",
+      CONCURRENCY: concurrency,
+    })
+
+  test("should throw an error is code version does not exists", async () => {
+    initCodeLocationMock(codeName)
+    const expected = new Error("Error with code exists")
+    when(codeExistsMock)
+      .calledWith(request.codeName)
+      .mockRejectedValueOnce(expected)
+
+    await expect(updateByConsumerIds(request)).rejects.toBe(expected)
+  })
+
+  test("should throw an error if lambda details can not be found for 1 consumer", async () => {
+    initCodeLocationMock(codeName)
+    const expected = new Error("Error getting lambda details")
+
+    when(getLambdaEnvVarsMock)
+      .calledWith(validLambdaName(request.consumerIds[1]))
+      .mockRejectedValueOnce(expected)
+
+    await expect(updateByConsumerIds(request)).rejects.toBe(expected)
+  })
+
+  test("should return success if no lambdas need updated", async () => {
+    initCodeLocationMock(codeName)
+    const expected = {
+      statusCode: 200,
+      body: {
+        message: "Completed, verify logs for individual handler updates",
+      },
+    }
+
+    const results = await updateByConsumerIds(request)
+    expect(results).toEqual(expected)
+    expect(updateFunctionCode).toHaveBeenCalledTimes(0)
+    expect(updateFunctionConfiguration).toHaveBeenCalledTimes(0)
+    expect(waitFor).toHaveBeenCalledTimes(0)
+  })
+
+  const initMocks = (id: ConsumerId, codeLocation: Location) => {
+    const lambdaName = validLambdaName(id)
+    when(updateFunctionCode)
+      .calledWith({
+        FunctionName: lambdaName,
+        Publish: true,
+        S3Bucket: codeLocation.bucket,
+        S3Key: codeLocation.key,
+      })
+      .mockReturnValue({ promise: () => ({}) })
+
+    when(waitFor)
+      .calledWith("functionUpdatedV2", {
+        FunctionName: lambdaName,
+      })
+      .mockReturnValue({ promise: () => ({}) })
+
+    when(updateFunctionConfiguration)
+      .calledWith({
+        Environment: {
+          Variables: {
+            VERSION: codeLocation.version,
+            Environment: "local",
+            CONCURRENCY: concurrency,
+          },
+        },
+        FunctionName: lambdaName,
+        MemorySize: 128,
+        Runtime: request.nodeVersion,
+        Timeout: 32,
+      })
+      .mockReturnValue({
+        promise: () => Promise.resolve({ FunctionArn: lambdaName }),
+      })
+  }
+  test("should update versions that don't match", async () => {
+    const codeName = "2024-08-28T16:41:33.184Z"
+    const codeLocation = initCodeLocationMock(codeName)
+    initMocks(request.consumerIds[0], codeLocation)
+    initMocks(request.consumerIds[1], codeLocation)
+    const result = await updateByConsumerIds({ ...request, codeName: codeName })
+
+    expect(result).toEqual({
+      statusCode: 200,
+      body: {
+        message: "Completed, verify logs for individual handler updates",
+      },
+    })
+
+    expect(updateFunctionCode).toHaveBeenCalledTimes(2)
+    expect(waitFor).toHaveBeenCalledTimes(2)
+    expect(updateFunctionConfiguration).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/updateCode/util.test.ts
+++ b/test/updateCode/util.test.ts
@@ -1,0 +1,69 @@
+import { UpdateConsumersCodeRequest } from "../../src"
+import { validateUpdateConsumersCodeRequest } from "../../src/updateCode/util"
+
+describe("util", () => {
+  describe("validateUpdateConsumersCodeRequest", () => {
+    test("should throw an error if no consumers passed in", () => {
+      const request = {} as UpdateConsumersCodeRequest
+      const expected = new Error("Consumers array is empty or not provided")
+
+      expect(() => validateUpdateConsumersCodeRequest(request)).toThrow(
+        expected
+      )
+    })
+
+    test("should throw an error if code name is not passed in", () => {
+      const request = {
+        consumerIds: [123, "app1"],
+      } as UpdateConsumersCodeRequest
+      const expected = new Error("Code name is empty or not provided")
+
+      expect(() => validateUpdateConsumersCodeRequest(request)).toThrow(
+        expected
+      )
+    })
+
+    test("should return error if node version is not passed in", () => {
+      const request = {
+        consumerIds: [123, "app1"],
+        codeName: "testName",
+      } as UpdateConsumersCodeRequest
+      const expected = new Error("Node version is empty or not provided")
+
+      expect(() => validateUpdateConsumersCodeRequest(request)).toThrow(
+        expected
+      )
+    })
+
+    test("should return error if node version is not allowed", () => {
+      const request = {
+        consumerIds: [123, "app1"],
+        codeName: "testName",
+        nodeVersion: "nodejs18.x",
+      } as UpdateConsumersCodeRequest
+      const expected = new Error("Node version is not supported")
+
+      expect(() => validateUpdateConsumersCodeRequest(request)).toThrow(
+        expected
+      )
+    })
+
+    test("should return valid UpdateConsumersCodeRequest", () => {
+      const request = {
+        consumerIds: [123, "app1"],
+        codeName: "testName ",
+        nodeVersion: "nodejs20.x ",
+      }
+
+      const expected = {
+        consumerIds: [123, "app1"],
+        codeName: "testName",
+        nodeVersion: "nodejs20.x",
+      }
+
+      expect(validateUpdateConsumersCodeRequest(request)).toStrictEqual(
+        expected
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Changes
- Created a new lambda to update webhook handlers by consumer ids

Request:
```
{
    consumerIds: [1, 2, 3, "app1"],
    nodeVersion: "" // "nodejs20.x" || "nodejs16.x"
    codeName: "s3 package name to use"
}
```

## Testing
Outside of the unit test we will need to test this in devint to verify the lambda resources are updated as expected